### PR TITLE
Drop DRM master after opening card

### DIFF
--- a/reframe-streamer/main.c
+++ b/reframe-streamer/main.c
@@ -492,6 +492,7 @@ _get_card_and_connector(struct _this *this, const char *connector_name)
 		);
 		return NULL;
 	}
+	drmDropMaster(this->cfd);
 	g_message("DRM: Opened card %s.", this->card_path);
 	return _get_connector(this->cfd, connector_name);
 }


### PR DESCRIPTION
This allows other processes to become DRM master.

Closes <https://github.com/AlynxZhou/reframe/issues/6>.