### PR TITLE
Load VNC server implementation at runtime using plugins.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -64,6 +64,7 @@ conf_data = configuration_data()
 conf_data.set_quoted('PROJECT_VERSION', meson.project_version())
 conf_data.set_quoted('USERNAME', username)
 conf_data.set_quoted('BINDIR', bindir)
+conf_data.set_quoted('LIBDIR', libdir)
 conf_data.set('HAVE_LIBSYSTEMD', get_option('systemd') and libsystemd.found())
 conf_data.set('HAVE_NEATVNC', get_option('neatvnc') and neatvnc.found())
 

--- a/reframe-common/config.h.in
+++ b/reframe-common/config.h.in
@@ -4,6 +4,7 @@
 #mesondefine PROJECT_VERSION
 #mesondefine USERNAME
 #mesondefine BINDIR
+#mesondefine LIBDIR
 #mesondefine HAVE_LIBSYSTEMD
 #mesondefine HAVE_NEATVNC
 

--- a/reframe-server/meson.build
+++ b/reframe-server/meson.build
@@ -1,18 +1,17 @@
+# Main executable sources (no longer includes VNC server implementations)
 sources = files(
   'main.c',
   'rf-streamer.c',
   'rf-session.c',
   'rf-converter.c',
-  'rf-vnc-server.c',
-  'rf-lvnc-server.c'
+  'rf-vnc-server.c'
 )
 
 headers = files(
   'rf-streamer.h',
   'rf-session.h',
   'rf-converter.h',
-  'rf-vnc-server.h',
-  'rf-lvnc-server.h'
+  'rf-vnc-server.h'
 )
 
 dependencies = []
@@ -21,19 +20,10 @@ m = cc.find_library('m')
 glib = dependency('glib-2.0', required: true)
 gio = dependency('gio-2.0', required: true)
 gio_unix = dependency('gio-unix-2.0', required: true)
+gmodule = dependency('gmodule-2.0', required: true)
 epoxy = dependency('epoxy', required: true)
-libvncserver = dependency('libvncserver', required: true)
 xkbcommon = dependency('xkbcommon', required: true)
-dependencies += [m, glib, gio, gio_unix, epoxy, libvncserver, xkbcommon]
-
-if get_option('neatvnc') and neatvnc.found()
-  sources += files('rf-nvnc-server.c')
-  headers += files('rf-nvnc-server.h')
-  libdrm = dependency('libdrm', required: true)
-  aml = dependency('aml', required: true)
-  pixman = dependency('pixman-1', required: true)
-  dependencies += [libdrm, aml, pixman, neatvnc]
-endif
+dependencies += [m, glib, gio, gio_unix, gmodule, epoxy, xkbcommon]
 
 dependencies += [mvmath_dep, reframe_common_dep]
 
@@ -48,3 +38,32 @@ executable(
   include_directories: include_directories,
   install: true
 )
+
+vnc_plugin_dir = get_option('libdir') / 'reframe' / 'vnc'
+libvncserver = dependency('libvncserver', required: true)
+
+shared_module(
+  'rf-lvnc-server',
+  sources: files('rf-lvnc-server.c'),
+  dependencies: [glib, gio, libvncserver, reframe_common_dep],
+  include_directories: include_directories,
+  name_prefix: '',
+  install: true,
+  install_dir: vnc_plugin_dir
+)
+
+if get_option('neatvnc') and neatvnc.found()
+  libdrm = dependency('libdrm', required: true)
+  aml = dependency('aml', required: true)
+  pixman = dependency('pixman-1', required: true)
+
+  shared_module(
+    'rf-nvnc-server',
+    sources: files('rf-nvnc-server.c'),
+    dependencies: [glib, gio, libdrm, aml, pixman, neatvnc, reframe_common_dep],
+    include_directories: include_directories,
+    name_prefix: '',
+    install: true,
+    install_dir: vnc_plugin_dir
+  )
+endif

--- a/reframe-server/rf-lvnc-server.c
+++ b/reframe-server/rf-lvnc-server.c
@@ -381,7 +381,7 @@ static void rf_lvnc_server_init(RfLVNCServer *this)
 	this->running = false;
 }
 
-RfVNCServer *rf_lvnc_server_new(RfConfig *config)
+G_MODULE_EXPORT RfVNCServer *rf_vnc_server_new(RfConfig *config)
 {
 	RfLVNCServer *this = g_object_new(RF_TYPE_LVNC_SERVER, NULL);
 	this->config = config;

--- a/reframe-server/rf-nvnc-server.c
+++ b/reframe-server/rf-nvnc-server.c
@@ -2,8 +2,6 @@
 #include <glib-unix.h>
 #define AML_UNSTABLE_API 1
 #include <aml.h>
-// XXX: There are several bugs in neatvnc's encoding, JPEG compress will make it
-// crash on start, and tight encoding will make it crash with GNOME overview.
 #include <neatvnc.h>
 #include <pixman.h>
 #include <libdrm/drm_fourcc.h>
@@ -374,7 +372,7 @@ static void rf_nvnc_server_init(RfNVNCServer *this)
 	this->running = false;
 }
 
-RfVNCServer *rf_nvnc_server_new(RfConfig *config)
+G_MODULE_EXPORT RfVNCServer *rf_vnc_server_new(RfConfig *config)
 {
 	RfNVNCServer *this = g_object_new(RF_TYPE_NVNC_SERVER, NULL);
 	this->config = config;


### PR DESCRIPTION
libvncserver overrides tjCompress2 from libturbojpeg causing neatvnc to crash when JPEG compression is used. This can be seen in the stack trace when the crash occurs. To fix this, load libvncserver and neatvnc only if needed using plugins.

Closes <https://github.com/AlynxZhou/reframe/issues/13>.