### PR TITLE
Set confdir permissions when installing to match reframe-tmpfiles.conf.

### DIFF
--- a/dists/meson.build
+++ b/dists/meson.build
@@ -56,6 +56,11 @@ configure_file(
   install_dir: xdgautostartdir
 )
 
+install_emptydir(
+  confdir,
+  install_mode: 'rwxr-x---'
+)
+
 install_data(
   'example.conf',
   install_dir: confdir


### PR DESCRIPTION
Avoids the directory permissions for /etc/reframe changing between 0755 and 0750 unnecessarily which results in a warning when updating package on Arch Linux.