### PR TITLE
Skip connected DRM outputs without an active CRTC

### DIFF
--- a/reframe-streamer/main.c
+++ b/reframe-streamer/main.c
@@ -521,6 +521,23 @@ static inline char *get_connector_name(drmModeConnector *connector)
 	);
 }
 
+static bool connector_has_crtc(int cfd, drmModeConnector *connector)
+{
+	drmModeEncoder *encoder = NULL;
+	bool has_crtc = false;
+
+	if (connector->encoder_id == 0)
+		return false;
+
+	encoder = drmModeGetEncoder(cfd, connector->encoder_id);
+	if (encoder == NULL)
+		return false;
+
+	has_crtc = encoder->crtc_id != 0;
+	drmModeFreeEncoder(encoder);
+	return has_crtc;
+}
+
 static drmModeConnector *get_connector(int cfd, const char *connector_name)
 {
 	drmModeConnector *connector = NULL;
@@ -542,6 +559,16 @@ static drmModeConnector *get_connector(int cfd, const char *connector_name)
 			connector->connection == DRM_MODE_CONNECTED ?
 				"connected" :
 				"disconnected");
+		if (connector->connection == DRM_MODE_CONNECTED &&
+		    !connector_has_crtc(cfd, connector)) {
+			g_debug(
+				"DRM: Skipping connector %s because it has no active CRTC.",
+				full_name
+			);
+			drmModeFreeConnector(connector);
+			connector = NULL;
+			continue;
+		}
 		if (connector->connection == DRM_MODE_CONNECTED &&
 		    (connector_name == NULL ||
 		     g_strcmp0(full_name, connector_name) == 0))
@@ -569,7 +596,7 @@ get_connected_card_and_connector(struct this *this, const char *connector_name)
 		int cfd = open(card_path, O_RDONLY | O_CLOEXEC);
 		if (cfd < 0)
 			continue;
-		g_debug("DRM: Finding the first connected connector on card %s.",
+		g_debug("DRM: Finding the first connected connector with an active CRTC on card %s.",
 			card_path);
 		drmModeConnector *connector =
 			get_connector(cfd, connector_name);
@@ -577,7 +604,7 @@ get_connected_card_and_connector(struct this *this, const char *connector_name)
 			this->cfd = cfd;
 			this->card_path = g_strdup(card_path);
 			g_message(
-				"DRM: Found the first connected connector on card %s.",
+				"DRM: Found the first connected connector with an active CRTC on card %s.",
 				card_path
 			);
 			return connector;


### PR DESCRIPTION
## Summary
- skip DRM connectors that are reported as connected but have no active CRTC
- avoid auto-selecting disabled outputs like a laptop panel when another display is actually driving the desktop
- keep automatic output selection working without requiring manual card/connector configuration
