### PR TITLE
Fix undeclared systemd and neatvnc variables

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -93,7 +93,7 @@ summary({
   'moduledir': moduledir,
   'confdir': confdir,
 }, section: 'Configuration')
-if systemd.found()
+if get_option('systemd') and systemd.found()
   summary({
     'systemunitdir': systemunitdir,
     'sysusersdir': sysusersdir,
@@ -101,7 +101,7 @@ if systemd.found()
     'username': username
   }, section: 'Configuration')
 endif
-if neatvnc.found()
+if get_option('neatvnc') and neatvnc.found()
   summary({
     'neatvnc unstable API': neatvnc_unstable_api
   }, section: 'Configuration')


### PR DESCRIPTION
If `neatvnc` and `systemd` options are initialized with `false`, the `systemd` and `neatvnc` variables stay undeclared and fail on configure.

```
$ meson setup . ..
../meson.build:104:11: ERROR: Unknown variable "neatvnc".
$ meson setup . .. -Dneatvnc=false
../meson.build:104:11: ERROR: Unknown variable "neatvnc".
$ meson setup . .. -Dneatvnc=true -Dsystemd=false
../meson.build:96:11: ERROR: Unknown variable "systemd".
```