### PR TITLE
Add neatvnc option for RSA private key file.

### DIFF
--- a/dists/example.conf
+++ b/dists/example.conf
@@ -51,3 +51,4 @@ type=libvncserver
 # modern security types, such as macOS Screen Sharing. Otherwise set to `false`
 # to improve security.
 allow-broken-crypto=false
+rsa-private-key-file=

--- a/reframe-common/rf-config.c
+++ b/reframe-common/rf-config.c
@@ -342,3 +342,16 @@ bool rf_config_get_neatvnc_allow_broken_crypto(RfConfig *this)
 		return false;
 	return allow_broken_crypto;
 }
+
+char *rf_config_get_neatvnc_rsa_private_key_file(RfConfig *this)
+{
+	g_return_val_if_fail(RF_IS_CONFIG(this), NULL);
+
+	g_autoptr(GError) error = NULL;
+	char *key_file = g_key_file_get_string(
+		this->f, RF_CONFIG_GROUP_NEATVNC, "rsa-private-key-file", &error
+	);
+	if (error != NULL || key_file == NULL || key_file[0] == '\0')
+		return NULL;
+	return key_file;
+}

--- a/reframe-common/rf-config.h
+++ b/reframe-common/rf-config.h
@@ -35,6 +35,7 @@ unsigned int rf_config_get_vnc_port(RfConfig *this);
 char *rf_config_get_vnc_password(RfConfig *this);
 char *rf_config_get_vnc_type(RfConfig *this);
 bool rf_config_get_neatvnc_allow_broken_crypto(RfConfig *this);
+char *rf_config_get_neatvnc_rsa_private_key_file(RfConfig *this);
 
 G_END_DECLS
 

--- a/reframe-server/rf-nvnc-server.c
+++ b/reframe-server/rf-nvnc-server.c
@@ -25,6 +25,7 @@ struct _RfNVNCServer {
 	unsigned int height;
 	bool resize;
 	bool allow_broken_crypto;
+	char *rsa_private_key_file;
 	bool running;
 };
 G_DEFINE_TYPE(RfNVNCServer, rf_nvnc_server, RF_TYPE_VNC_SERVER)
@@ -229,6 +230,8 @@ static void start(RfVNCServer *super)
 	);
 	this->allow_broken_crypto =
 		rf_config_get_neatvnc_allow_broken_crypto(this->config);
+	this->rsa_private_key_file =
+		rf_config_get_neatvnc_rsa_private_key_file(this->config);
 
 	this->clients = 0;
 
@@ -277,6 +280,8 @@ static void start(RfVNCServer *super)
 #endif
 	if (this->password != NULL && this->password[0] != '\0')
 		nvnc_enable_auth(this->nvnc, auth_flags, on_auth, this);
+	if (this->rsa_private_key_file)
+		nvnc_set_rsa_creds(this->nvnc, this->rsa_private_key_file);
 	struct pixman_region16 region;
 	pixman_region_init_rect(&region, 0, 0, this->width, this->height);
 #ifndef NEATVNC_UNSTABLE_API


### PR DESCRIPTION
This allows the fingerprint displayed by the client to remain the same to avoid eavesdropping and MITM attacks, otherwise the fingerprint would change every time the server is restarted.

See <https://github.com/AlynxZhou/reframe/issues/34>.