### PR TITLE
Support older GLib versions.

### DIFF
--- a/reframe-server/main.c
+++ b/reframe-server/main.c
@@ -1,5 +1,6 @@
 #include <locale.h>
 #include <glib-unix.h>
+#include <glib/gstdio.h>
 #include <gmodule.h>
 
 #include "config.h"

--- a/reframe-server/rf-session.c
+++ b/reframe-server/rf-session.c
@@ -1,5 +1,7 @@
 #include <stdbool.h>
+#include <gio/gunixsocketaddress.h>
 #include <glib.h>
+#include <glib/gstdio.h>
 #include <glib-unix.h>
 
 #include "rf-common.h"

--- a/reframe-server/rf-streamer.c
+++ b/reframe-server/rf-streamer.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 #include <gio/gio.h>
 #include <gio/gunixfdmessage.h>
+#include <gio/gunixsocketaddress.h>
 #include <linux/uinput.h>
 
 #include "rf-common.h"

--- a/reframe-server/rf-vnc-server.c
+++ b/reframe-server/rf-vnc-server.c
@@ -3,6 +3,35 @@
 #include "rf-common.h"
 #include "rf-vnc-server.h"
 
+#if !GLIB_CHECK_VERSION(2, 74, 0)
+typedef void (*GSourceOnceFunc)(gpointer user_data);
+
+typedef struct {
+    GSourceOnceFunc func;
+    gpointer data;
+} IdleOnceData;
+
+static gboolean idle_once_cb(gpointer user_data)
+{
+    IdleOnceData *d = user_data;
+
+    d->func(d->data);
+    g_free(d);
+
+    return G_SOURCE_REMOVE;
+}
+
+static guint g_idle_add_once(GSourceOnceFunc func, gpointer data)
+{
+    IdleOnceData *d = g_new(IdleOnceData, 1);
+
+    d->func = func;
+    d->data = data;
+
+    return g_idle_add(idle_once_cb, d);
+}
+#endif
+
 typedef struct _RfVNCServerPrivate {
 	struct xkb_context *xkb_context;
 	struct xkb_keymap *xkb_keymap;

--- a/reframe-session/main.c
+++ b/reframe-session/main.c
@@ -2,6 +2,7 @@
 #include <glib.h>
 #include <glib-unix.h>
 #include <gio/gio.h>
+#include <gio/gunixsocketaddress.h>
 #include <gtk/gtk.h>
 #include <gdk/gdk.h>
 

--- a/reframe-streamer/main.c
+++ b/reframe-streamer/main.c
@@ -3,8 +3,10 @@
 #include <locale.h>
 #include <glib.h>
 #include <glib-unix.h>
+#include <glib/gstdio.h>
 #include <gio/gio.h>
 #include <gio/gunixfdmessage.h>
+#include <gio/gunixsocketaddress.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 #include <libdrm/drm_fourcc.h>


### PR DESCRIPTION
Headers need to be explicitly included before using functions and the g_idle_add_once function is not available before GLib 2.74 so need to include a wrapper that uses g_idle_add instead.

Tested with GLib 2.72.