### PR TITLE
Add follow-the-cursor multi-monitor cursor support

### DIFF
--- a/dists/example.conf
+++ b/dists/example.conf
@@ -24,6 +24,23 @@ default-height=0
 resize=true
 # Set to `false` to ignore DRM cursor plane.
 cursor=true
+# Cross-monitor cursor follow (multi-monitor on compositors that confine an
+# absolute pointer to a single output, e.g. cosmic-comp / COSMIC on Wayland).
+# The streamer detects which monitor physically shows the cursor (via the DRM
+# cursor plane) and, when a pointer event arrives for a monitor that does NOT
+# currently have the cursor, performs one relative burst to bring the cursor
+# onto this monitor before forwarding the absolute event.
+#
+# `position-x` is this monitor's real desktop X-position (top-left corner) in
+# desktop pixels. It is used ONLY as this monitor's owner identity and to pick
+# the relocation direction; it is SEPARATE from `monitor-x`. Keep
+# `desktop-width` = THIS monitor's width and `monitor-x` = 0 so absolute
+# positioning stays precise/full-range within the monitor.
+#
+# Example (DP-1 leftmost at x=0, DP-3 to its right at x=1920):
+#   DP-1:  position-x=0      (plus desktop-width=<DP-1 width>, monitor-x=0)
+#   DP-3:  position-x=1920   (plus desktop-width=<DP-3 width>, monitor-x=0)
+position-x=0
 # Set to `false` if you already disabled automatic screen blank.
 wakeup=true
 # Set to `gpu` to use GPU damage region detection, which may be more efficiency

--- a/reframe-common/rf-config.c
+++ b/reframe-common/rf-config.c
@@ -203,6 +203,24 @@ bool rf_config_get_cursor(RfConfig *this)
 	return cursor;
 }
 
+// The real desktop X-position (in desktop pixels) of this monitor's top-left
+// corner. Used only as the monitor's "owner identity" for cross-monitor cursor
+// relocation and to pick the burst direction; it is SEPARATE from monitor-x
+// (which stays 0 so absolute positioning is full-range within the monitor).
+// Default 0.
+int rf_config_get_position_x(RfConfig *this)
+{
+	g_return_val_if_fail(RF_IS_CONFIG(this), 0);
+
+	g_autoptr(GError) error = NULL;
+	int position_x = g_key_file_get_integer(
+		this->f, RF_CONFIG_GROUP_REFRAME, "position-x", &error
+	);
+	if (error != NULL)
+		return 0;
+	return position_x;
+}
+
 bool rf_config_get_wakeup(RfConfig *this)
 {
 	g_return_val_if_fail(RF_IS_CONFIG(this), true);

--- a/reframe-common/rf-config.h
+++ b/reframe-common/rf-config.h
@@ -27,6 +27,7 @@ unsigned int rf_config_get_default_width(RfConfig *this);
 unsigned int rf_config_get_default_height(RfConfig *this);
 bool rf_config_get_resize(RfConfig *this);
 bool rf_config_get_cursor(RfConfig *this);
+int rf_config_get_position_x(RfConfig *this);
 bool rf_config_get_wakeup(RfConfig *this);
 enum rf_damage_type rf_config_get_damage(RfConfig *this);
 unsigned int rf_config_get_fps(RfConfig *this);

--- a/reframe-streamer/main.c
+++ b/reframe-streamer/main.c
@@ -1,3 +1,5 @@
+#include <fcntl.h>
+#include <sys/file.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <locale.h>
@@ -21,6 +23,23 @@
 #endif
 
 #define WAKEUP_MAX_EVENTS 4
+
+// Shared file recording which monitor currently owns (shows) the system cursor.
+// It holds one int: the position-x of that monitor. Both per-monitor streamers
+// read/write it under an exclusive flock. The owner is published from the frame
+// path (cursor plane present => we own it); on_input_msg reads it to decide
+// whether the cursor needs to be relocated onto this monitor first.
+#define CURSOR_OWNER_PATH "/run/reframe/cursor-owner"
+
+// Cross-monitor relocation is emitted as a BURST of small relative steps, not
+// one giant delta: COSMIC/libinput ignores (or caps) a single huge REL_X, but
+// honors many small steps spaced a few ms apart (empirically confirmed).
+#define RELOCATE_STEP_PX 40 // px per relative step.
+// 120 * 40 = 4800px > desktop width, so the cursor clamps at this monitor's side
+// no matter which monitor it started on.
+#define RELOCATE_STEP_COUNT 120
+// Spacing between steps; libinput needs this gap to honor each motion.
+#define RELOCATE_STEP_DELAY_US 3000
 
 // clang-format off
 #define ioctl_must(...)                                                         \
@@ -59,6 +78,10 @@
 struct this {
 	RfConfig *config;
 	GSocketConnection *connection;
+	// This monitor's real desktop X-position (config key "position-x"). Used
+	// as the monitor's owner identity in CURSOR_OWNER_PATH and to choose the
+	// relocation burst direction. Separate from monitor-x (which stays 0).
+	int position_x;
 	char *card_path;
 	char *connector_name;
 	int cfd;
@@ -67,6 +90,9 @@ struct this {
 	bool cursor;
 	uint32_t cursor_id;
 	int ufd;
+	// Separate relative-only pointer device, used only for the cross-monitor
+	// cursor relocation burst (see setup_uinput / issue #36).
+	int ufd_rel;
 	bool wakeup;
 	bool skip_auth;
 };
@@ -360,6 +386,61 @@ out:
 	return ret;
 }
 
+// Shared cursor-owner file helpers. The file holds one int: the position-x of
+// the monitor that currently shows the system cursor. Access is serialized with
+// an exclusive flock so the two streamer processes don't race.
+
+// Publish that THIS monitor now owns the cursor (called from the frame path when
+// our CRTC has a cursor plane this frame).
+static void cursor_owner_publish(struct this *this)
+{
+	int fd = open(CURSOR_OWNER_PATH, O_WRONLY | O_CREAT | O_CLOEXEC, 0600);
+	if (fd < 0) {
+		g_warning(
+			"Cursor: Failed to open %s for publish: %s.",
+			CURSOR_OWNER_PATH,
+			strerror(errno)
+		);
+		return;
+	}
+	if (flock(fd, LOCK_EX) == 0) {
+		int v = this->position_x;
+		// The file only ever holds one int at offset 0, so a fixed-size
+		// overwrite keeps it exactly sizeof(int) without truncation.
+		if (lseek(fd, 0, SEEK_SET) != 0 ||
+		    write(fd, &v, sizeof(v)) != (ssize_t)sizeof(v))
+			g_warning("Cursor: Failed to write owner position.");
+	}
+	close(fd);
+}
+
+// Read the current owner's position-x. Returns true and sets *owner_x on
+// success; false if the file is missing/empty/unreadable (caller skips
+// relocation in that case).
+static bool cursor_owner_read(int *owner_x)
+{
+	int fd = open(CURSOR_OWNER_PATH, O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
+		return false;
+	bool ok = false;
+	if (flock(fd, LOCK_EX) == 0) {
+		int v = 0;
+		if (read(fd, &v, sizeof(v)) == (ssize_t)sizeof(v)) {
+			*owner_x = v;
+			ok = true;
+		}
+	}
+	close(fd);
+	return ok;
+}
+
+// Optimistically record THIS monitor as the owner after relocating the cursor
+// onto it, so we don't re-burst before the next frame refreshes the file.
+static void cursor_owner_claim(struct this *this)
+{
+	cursor_owner_publish(this);
+}
+
 static ssize_t on_frame_msg(struct this *this)
 {
 	g_debug("Frame: Received frame message.");
@@ -425,6 +506,13 @@ static ssize_t on_frame_msg(struct this *this)
 		// It is OK to ignore cursor plane if failed.
 		if (ret <= 0)
 			--length;
+		else
+			// A cursor plane is present on our CRTC this frame, so
+			// the system cursor is physically on THIS monitor.
+			// Publish ourselves as the owner. When the cursor is on
+			// the other monitor, our CRTC has no cursor plane, so we
+			// don't publish and the other streamer claims it.
+			cursor_owner_publish(this);
 	}
 
 	ret = send_frame_msg(this, length, bufs);
@@ -433,6 +521,27 @@ static ssize_t on_frame_msg(struct this *this)
 		for (unsigned int j = 0; j < bufs[i].md.length; ++j)
 			close(bufs[i].fds[j]);
 	return ret;
+}
+
+// Bring the system cursor onto THIS monitor with a burst of small relative
+// steps on the relative-only device (COSMIC ignores a single huge REL_X but
+// honors many small steps; issue #36 means the slam must come from a non-
+// absolute device). `dir` is the sign of the move. The burst overshoots so the
+// cursor clamps at this monitor's side regardless of where it started.
+static void cursor_relocate(struct this *this, int dir)
+{
+	struct input_event step[2];
+	memset(step, 0, sizeof(step));
+	step[0].type = EV_REL;
+	step[0].code = REL_X;
+	step[0].value = dir * RELOCATE_STEP_PX;
+	step[1].type = EV_SYN;
+	step[1].code = SYN_REPORT;
+	step[1].value = 0;
+	for (int i = 0; i < RELOCATE_STEP_COUNT; ++i) {
+		write_may(this->ufd_rel, step, sizeof(step));
+		g_usleep(RELOCATE_STEP_DELAY_US);
+	}
 }
 
 static ssize_t on_input_msg(struct this *this)
@@ -453,6 +562,29 @@ static ssize_t on_input_msg(struct this *this)
 	ret = g_input_stream_read(is, ies, length * sizeof(*ies), NULL, &error);
 	if (ret <= 0)
 		goto out;
+
+	// "Follow the stream": this event is for THIS monitor's stream, so the
+	// user wants the cursor here. If the cursor is currently on a DIFFERENT
+	// monitor (owner_x != my_x), first relocate it onto this monitor with a
+	// relative burst (which also flips the active output to us); then forward
+	// the absolute event unchanged, which now positions precisely on this
+	// monitor. If the cursor is already here (or owner is unknown), just
+	// forward the absolute. No edge zones, no thresholds, no ABS override.
+	int owner_x = 0;
+	if (cursor_owner_read(&owner_x) && owner_x != this->position_x) {
+		const int dir = this->position_x > owner_x ? 1 : -1;
+		g_message(
+			"Cursor: Relocating from owner x=%d to this monitor x=%d (dir %d) on %s.",
+			owner_x,
+			this->position_x,
+			dir,
+			this->connector_name
+		);
+		cursor_relocate(this, dir);
+		// Optimistically claim ownership so we don't re-burst before the
+		// next frame refreshes the owner file.
+		cursor_owner_claim(this);
+	}
 
 	write_may(this->ufd, ies, length * sizeof(*ies));
 
@@ -671,6 +803,15 @@ static void setup_drm(struct this *this)
 
 	send_card_path_msg(this, this->card_path);
 	send_connector_name_msg(this, this->connector_name);
+
+	// This monitor's real desktop position, used for cursor-owner identity
+	// and relocation burst direction (separate from monitor-x).
+	this->position_x = rf_config_get_position_x(this->config);
+	g_message(
+		"Cursor: This monitor position-x is %d on %s.",
+		this->position_x,
+		this->connector_name
+	);
 }
 
 static void clean_drm(struct this *this)
@@ -733,13 +874,13 @@ static void setup_uinput(struct this *this)
 	ioctl_must(this->ufd, UI_SET_ABSBIT, ABS_X);
 	ioctl_must(this->ufd, UI_SET_ABSBIT, ABS_Y);
 
-	// It seems trying to be both touchscreen and mouse leads into bugs,
-	// anyway, we only send absolute coordinates.
+	// This device stays ABSOLUTE-ONLY for positioning. We deliberately do
+	// NOT advertise REL_X/REL_Y here: a device that is both absolute and
+	// relative gets classified by COSMIC as an absolute pointer, and its
+	// relative motion is ignored (reframe issue #36). The relocation burst
+	// is emitted on a separate relative-only device (this->ufd_rel) below.
 	//
 	// See <https://github.com/AlynxZhou/reframe/issues/36>.
-	// ioctl_must(this->ufd, UI_SET_RELBIT, REL_X);
-	// ioctl_must(this->ufd, UI_SET_RELBIT, REL_Y);
-
 	ioctl_must(this->ufd, UI_SET_RELBIT, REL_WHEEL);
 	ioctl_must(this->ufd, UI_SET_RELBIT, REL_HWHEEL);
 
@@ -758,6 +899,35 @@ static void setup_uinput(struct this *this)
 	strcpy(dev.name, "reframe");
 	ioctl_must(this->ufd, UI_DEV_SETUP, &dev);
 	ioctl_must(this->ufd, UI_DEV_CREATE);
+
+	// Second device: a pure RELATIVE pointer used ONLY for the cross-monitor
+	// cursor relocation burst. A relative-only device is honored by COSMIC for
+	// cross-monitor motion (verified on the box). We declare BTN_LEFT so libinput
+	// classifies it as a mouse, but we NEVER emit button events on it (the
+	// absolute device keeps button state); this avoids any stuck-button risk.
+	this->ufd_rel = open("/dev/uinput", O_WRONLY | O_NONBLOCK);
+	if (this->ufd_rel < 0)
+		this->ufd_rel = open("/dev/input/uinput", O_WRONLY | O_NONBLOCK);
+	if (this->ufd_rel < 0)
+		g_error(
+			"Input: Failed to open uinput for relative device: %s.",
+			strerror(errno)
+		);
+
+	ioctl_must(this->ufd_rel, UI_SET_EVBIT, EV_SYN);
+	ioctl_must(this->ufd_rel, UI_SET_EVBIT, EV_KEY);
+	ioctl_must(this->ufd_rel, UI_SET_EVBIT, EV_REL);
+	ioctl_must(this->ufd_rel, UI_SET_KEYBIT, BTN_LEFT);
+	ioctl_must(this->ufd_rel, UI_SET_RELBIT, REL_X);
+	ioctl_must(this->ufd_rel, UI_SET_RELBIT, REL_Y);
+
+	struct uinput_setup dev_rel = { 0 };
+	dev_rel.id.bustype = BUS_USB;
+	dev_rel.id.vendor = 0xa3a7;
+	dev_rel.id.product = 0x0004;
+	strcpy(dev_rel.name, "reframe-rel");
+	ioctl_must(this->ufd_rel, UI_DEV_SETUP, &dev_rel);
+	ioctl_must(this->ufd_rel, UI_DEV_CREATE);
 
 	// If screen is turned off, we cannot get CRTC, so we have to wake it up.
 	this->wakeup = rf_config_get_wakeup(this->config);
@@ -780,6 +950,11 @@ static void clean_uinput(struct this *this)
 		ioctl_may(this->ufd, UI_DEV_DESTROY);
 		close(this->ufd);
 		this->ufd = -1;
+	}
+	if (this->ufd_rel >= 0) {
+		ioctl_may(this->ufd_rel, UI_DEV_DESTROY);
+		close(this->ufd_rel);
+		this->ufd_rel = -1;
 	}
 }
 
@@ -880,6 +1055,7 @@ int main(int argc, char *argv[])
 	g_autofree struct this *this = g_malloc0(sizeof(*this));
 	this->cfd = -1;
 	this->ufd = -1;
+	this->ufd_rel = -1;
 	this->skip_auth = skip_auth;
 	this->config = rf_config_new(config_path);
 


### PR DESCRIPTION
## What this does

ReFrame runs one server per monitor, but on Wayland compositors (e.g. COSMIC/`cosmic-comp`) an *absolute* pointer device is confined to a single output, so the system cursor can't move between monitors. This adds "follow the cursor":

- each streamer publishes which monitor currently holds the cursor (detected from the DRM cursor plane each frame) to a flock-guarded file under `/run/reframe`;
- on a pointer event for a monitor that doesn't currently hold the cursor, the streamer relocates it with one short burst of relative motion on a **dedicated relative-only `uinput` device** (a single large `REL_X` is ignored/capped by libinput; many small steps a few ms apart are honored; related to #36), then forwards the absolute event for precise placement;
- **within** a monitor it's pure absolute input, so normal movement stays smooth and pixel-accurate.

New per-monitor config key `position-x` (the monitor's real desktop X position), kept separate from `monitor-x` so absolute scaling stays full-range per monitor. Documented in `dists/example.conf`. The existing device stays absolute-only; the relative-only device is added specifically to avoid the absolute+relative same-device problem from #36.

## Tested

Pop!_OS 24.04, COSMIC (`cosmic-comp`), Wayland, NVIDIA open kernel module 580.159.03, two monitors (1920×1080 + 1680×1050), VNC via libvncserver, client = Apache Guacamole. Verified crossing and precise in-monitor positioning in both directions and from either monitor's stream.

## Not tested / out of scope

- **Touchscreen devices on either the local or remote side**; we weren't equipped to test touch input, and since this area touches input-device classification (cf. #36), touchscreen behavior is unverified.
- Cross-monitor **drag-and-drop** is not handled (relocation teleports the cursor; a drag won't carry across).
- Only exercised on `cosmic-comp`; other Wayland compositors and X11 untested.

Happy to adjust the approach or naming to fit the project's conventions.
